### PR TITLE
Refactoring superagent-hawk

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,18 +76,19 @@ module.exports = function (superagent) {
   Request.prototype.end = function (response_handler) {
     this.end = oldEnd;
 
-    if (this._enable_hawk_signing)
-      artifacts = this._do_hawk_sign();
+    if (this._enable_hawk_signing) {
+      var artifacts = this._do_hawk_sign();
 
-    if (this._enable_hawk_response_verification) {
-      var hawk_credential = this._hawk_credential;
-      var wrapped_response_handler = function(result) {
-        verify_hawk_response(result, hawk_credential, artifacts);
-        return response_handler(result);
+      if (this._enable_hawk_response_verification) {
+        var hawk_credential = this._hawk_credential;
+        var wrapped_response_handler = function(result) {
+          verify_hawk_response(result, hawk_credential, artifacts);
+          return response_handler(result);
+        }
+        return this.end(wrapped_response_handler);
+      } else {
+        return this.end(response_handler);
       }
-      return this.end(wrapped_response_handler);
-    } else {
-      return this.end(response_handler);
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = function (superagent) {
     }
   };
 
-  RequestProto.bewit = function(bewit) {
+  Request.prototype.bewit = function(bewit) {
     this.query({ bewit: bewit });
     return this;
   };

--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ module.exports = function (superagent) {
         var hawk_credential = this._hawk_credential;
         var wrapped_response_handler = function(err, res) {
           verify_hawk_response(res, hawk_credential, artifacts);
-          return response_handler(err, res);
+          if (2 == response_handler.length) return response_handler(err, res);
+          if (err) return this.emit('error', err);
+          return response_handler(res);
         }
         return this.end(wrapped_response_handler);
       }

--- a/tests/bewit.js
+++ b/tests/bewit.js
@@ -44,11 +44,12 @@ test('server starts', function (t) {
   });
 });
 
+
 test('credential works', function (t) {
   request
     .get('http://localhost:8080')
     .bewit(bewit)
-    .end(function (res) {
+    .end(function (err, res) {
       t.equal(res.statusCode, 200, 'Responded 200');
       t.equal(res.text, 'Hello Steve', 'knows who I am');
       t.end();
@@ -59,19 +60,20 @@ test('wrong bewit won\'t work', function (t) {
   request
     .get('http://localhost:8080')
     .bewit(bewit+'should_not_be_here')
-    .end(function (res) {
+    .end(function (err, res) {
       t.equal(res.statusCode, 401, 'Responded 401');
       t.equal(res.text, 'Shoosh!', 'Not authenticated');
       t.end();
     });
 });
 
+
 test('an expired bewit won\'t work', function (t) {
   setTimeout(function () {
     request
       .get('http://localhost:8080')
       .bewit(bewit)
-      .end(function (res) {
+      .end(function (err, res) {
         t.equal(res.statusCode, 401, 'Responded 401');
         t.equal(res.text, 'Shoosh!', 'Not authenticated');
         t.end();


### PR DESCRIPTION
The hawk request signature is now generated in the `.end()` method instead of being generated when `.hawk()` is called. Calling `.hawk()` only enables the signature generation, but it is done at a later step.

This change gains additional flexibility in the order of method calls on the request object. For example both these orders work now:

```
// enable hawk before setting content type and passing data
request.post('http://localhost:5002/v1.0/servers/')
  .hawk(credential, options)
  .set('Content-Type', 'application/json')
  .send('{"name":"tj","pet":"tobi"}')
  .on('error', error_handler)
  .end(response_handler);

// enable hawk after setting content type and passing data
request.post('http://localhost:5002/v1.0/servers/')
  .set('Content-Type', 'application/json')
  .send('{"name":"tj","pet":"tobi"}')
  .on('error', error_handler)
  .hawk(credential, options)
  .end(response_handler);
```
